### PR TITLE
Ignore aws-lambda-jenkins-plugin and aws-lambda-jenkins

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -24,3 +24,5 @@ jgiven-plugin             # renamed to jgiven
 openstack-plugin          # renamed to openstack-cloud
 matrix-project-1.4.1      # this specific version is excluded for INFRA-250
 matrix-project-1.2.1      # also INFRA-250
+aws-lambda-jenkins-plugin # renamed to aws-lambda
+aws-lambda-jenkins        # renamed to aws-lambda


### PR DESCRIPTION
New plugin artifact id is aws-lambda to conform with artifact without -plugin guideline