### PR TITLE
Remove rtc

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -24,3 +24,4 @@ jgiven-plugin             # renamed to jgiven
 openstack-plugin          # renamed to openstack-cloud
 matrix-project-1.4.1      # this specific version is excluded for INFRA-250
 matrix-project-1.2.1      # also INFRA-250
+rtc                       # superseded by Team Concert Plugin


### PR DESCRIPTION
As stated on https://wiki.jenkins-ci.org/display/JENKINS/Rational+Team+Concert+Plugin for years:

> Deprecated since core 1.480.3.  Use Team Concert Plugin instead.