### PR TITLE
Add a lot of wiki overrides for plugins with incorrect/missing URLs.

### DIFF
--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -28,6 +28,19 @@ script-scm=https://wiki.jenkins-ci.org/display/JENKINS/Script+SCM+Plugin
 # this plugin was forked from Checkstyle, but didn't modify the <url> tag...
 jshint-checkstyle=https://wiki.jenkins-ci.org/display/JENKINS/JSHint+Checkstyle+Plugin
 
+# Required until each of the Workflow plugins provide a URL in their pom.xml files
+workflow-aggregator=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-api=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-basic-steps=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-cps=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-cps-global-lib=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-durable-task-step=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-job=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-scm-step=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-step-api=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-stm=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+workflow-support=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
+
 # Required until a new version with this URL in pom.xml is released
 additional-identities-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Additional+Identities+Plugin
 ApicaLoadtest=https://wiki.jenkins-ci.org/display/JENKINS/Apica+Loadtest+Plugin

--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -8,3 +8,70 @@ prereq-buildstep=http://wiki.jenkins-ci.org/display/JENKINS/Prerequisite+build+s
 qc=http://wiki.jenkins-ci.org/display/JENKINS/Quality+Center+Plugin
 skype-notifier=http://wiki.jenkins-ci.org/display/JENKINS/Skype+Plugin
 unicorn=http://wiki.jenkins-ci.org/display/JENKINS/Unicorn+Validation+Plugin
+
+# Required until a newer version than 1.1 is released
+archived-artifact-url-viewer=https://wiki.jenkins-ci.org/display/JENKINS/Archived+Artifact+Url+Viewer+PlugIn
+
+# Required until a newer version than 0.9.0-rc1 is released
+docker-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Docker+Plugin
+
+# Required until a newer version than 0.3 is released
+plugin-usage-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Plugin+Usage+Plugin+(Community)
+
+# Required until a newer version than 0.4.2 is released
+rpmsign-plugin=https://wiki.jenkins-ci.org/display/JENKINS/RPM+Sign+Plugin
+
+# Required until a newer version than 1.1.6 is released
+script-scm=https://wiki.jenkins-ci.org/display/JENKINS/Script+SCM+Plugin
+
+# Required until a new version with this URL in pom.xml is released
+additional-identities-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Additional+Identities+Plugin
+ApicaLoadtest=https://wiki.jenkins-ci.org/display/JENKINS/Apica+Loadtest+Plugin
+aws-lambda=https://wiki.jenkins-ci.org/display/JENKINS/AWS+Lambda+Plugin
+caroline=https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
+chef-tracking=https://wiki.jenkins-ci.org/display/JENKINS/Chef+Tracking+Plugin
+chosen-views-tabbar=https://wiki.jenkins-ci.org/display/JENKINS/Chosen+Views+Tab+Bar
+cloudbees-disk-usage-simple=https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Simple+Disk+Usage+Plugin
+cloudbees-enterprise-plugins=https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+cocoapods-integration=https://wiki.jenkins-ci.org/display/JENKINS/CocoaPods+Plugin
+cucumber-reports=https://wiki.jenkins-ci.org/display/JENKINS/Cucumber+Reports+Plugin
+custom-view-tabs=https://wiki.jenkins-ci.org/display/JENKINS/Custom+View+Tabs+Plugin
+database-drizzle=https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=65669136
+deployment-notification=https://wiki.jenkins-ci.org/display/JENKINS/Deployment+Notification+Plugin
+diskcheck=https://wiki.jenkins-ci.org/display/JENKINS/DiskCheck+Plugin
+docker-build-publish=https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Build+and+Publish+plugin
+dockerhub=https://wiki.jenkins-ci.org/display/JENKINS/DockerHub+Plugin
+dynamicparameter=https://wiki.jenkins-ci.org/display/JENKINS/Dynamic+Parameter+Plug-in
+figlet-buildstep=https://wiki.jenkins-ci.org/display/JENKINS/Figlet+plugin
+file-leak-detector=https://wiki.jenkins-ci.org/display/JENKINS/File+Leak+Detector+Plugin
+form-element-path=https://wiki.jenkins-ci.org/display/JENKINS/Form+Element+Path+Plugin
+gerrit=https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
+groovyaxis=https://wiki.jenkins-ci.org/display/JENKINS/GroovyAxis
+hckrnews=https://wiki.jenkins-ci.org/display/JENKINS/Hckrnews+Plugin
+icon-shim=https://wiki.jenkins-ci.org/display/JENKINS/Icon+Shim+Plugin
+image-gallery=https://wiki.jenkins-ci.org/display/JENKINS/Image+Gallery+Plugin
+jenkins-testswarm-plugin=https://wiki.jenkins-ci.org/display/JENKINS/testswarm-plugin
+job-direct-mail=https://wiki.jenkins-ci.org/display/JENKINS/Job+Direct+Mail+Plugin
+jython=https://wiki.jenkins-ci.org/display/JENKINS/Jython+Plugin
+koji=https://wiki.jenkins-ci.org/display/JENKINS/Koji+Plugin
+mailmap-resolver=https://wiki.jenkins-ci.org/display/JENKINS/Mail+Map+Resolver
+mansion-cloud=https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
+openJDK-native-plugin=https://wiki.jenkins-ci.org/display/JENKINS/OpenJDK+native+installer+plugin
+parallel-test-executor=https://wiki.jenkins-ci.org/display/JENKINS/Parallel+Test+Executor+Plugin
+periodicbackup=https://wiki.jenkins-ci.org/display/JENKINS/PeriodicBackup+Plugin
+php=https://wiki.jenkins-ci.org/display/JENKINS/PHP+Plugin
+project-health-report=https://wiki.jenkins-ci.org/display/JENKINS/Project+Health+Report+Plugin
+puppet=https://wiki.jenkins-ci.org/display/JENKINS/Puppet+Plugin
+ruby-runtime=https://wiki.jenkins-ci.org/display/JENKINS/Ruby+Runtime+Plugin
+serenity=https://wiki.jenkins-ci.org/display/JENKINS/Serenity+Plugin
+skytap=https://wiki.jenkins-ci.org/display/JENKINS/Skytap+Cloud+CI+Plugin
+smartfrog-plugin=https://wiki.jenkins-ci.org/display/JENKINS/SmartFrog+Plugin
+sonar=https://wiki.jenkins-ci.org/display/JENKINS/SonarQube+plugin
+started-by-envvar=https://wiki.jenkins-ci.org/display/JENKINS/Started-By+Environment+Variable+Plugin
+StashBranchParameter=https://wiki.jenkins-ci.org/display/JENKINS/StashBranchParameter
+svn-workspace-cleaner=https://wiki.jenkins-ci.org/display/JENKINS/SVN+Workspace+Cleaner
+text-finder-run-condition=https://wiki.jenkins-ci.org/display/JENKINS/Text+Finder+Run+Condition+Plugin
+vaddy-plugin=https://wiki.jenkins-ci.org/display/JENKINS/VAddy+Plugin
+violation-comments-to-stash=https://wiki.jenkins-ci.org/display/JENKINS/Violation+Comments+to+Stash+Plugin
+violations=https://wiki.jenkins-ci.org/display/JENKINS/Violations
+xpdev=https://wiki.jenkins-ci.org/display/JENKINS/XP-Dev+Plugin

--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -24,6 +24,10 @@ rpmsign-plugin=https://wiki.jenkins-ci.org/display/JENKINS/RPM+Sign+Plugin
 # Required until a newer version than 1.1.6 is released
 script-scm=https://wiki.jenkins-ci.org/display/JENKINS/Script+SCM+Plugin
 
+# Required until a new version with this URL in pom.xml is released;
+# this plugin was forked from Checkstyle, but didn't modify the <url> tag...
+jshint-checkstyle=https://wiki.jenkins-ci.org/display/JENKINS/JSHint+Checkstyle+Plugin
+
 # Required until a new version with this URL in pom.xml is released
 additional-identities-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Additional+Identities+Plugin
 ApicaLoadtest=https://wiki.jenkins-ci.org/display/JENKINS/Apica+Loadtest+Plugin

--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -41,6 +41,9 @@ workflow-step-api=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
 workflow-stm=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
 workflow-support=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
 
+# Should remain commented out until pull #20 is merged, otherwise UC generation fails
+#database-drizzle=https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=65669136
+
 # Required until a new version with this URL in pom.xml is released
 additional-identities-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Additional+Identities+Plugin
 ApicaLoadtest=https://wiki.jenkins-ci.org/display/JENKINS/Apica+Loadtest+Plugin
@@ -53,7 +56,6 @@ cloudbees-enterprise-plugins=https://wiki.jenkins-ci.org/display/JENKINS/CloudBe
 cocoapods-integration=https://wiki.jenkins-ci.org/display/JENKINS/CocoaPods+Plugin
 cucumber-reports=https://wiki.jenkins-ci.org/display/JENKINS/Cucumber+Reports+Plugin
 custom-view-tabs=https://wiki.jenkins-ci.org/display/JENKINS/Custom+View+Tabs+Plugin
-database-drizzle=https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=65669136
 deployment-notification=https://wiki.jenkins-ci.org/display/JENKINS/Deployment+Notification+Plugin
 diskcheck=https://wiki.jenkins-ci.org/display/JENKINS/DiskCheck+Plugin
 docker-build-publish=https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Build+and+Publish+plugin


### PR DESCRIPTION
I changed the update centre code to be more strict about wiki URLs, and examined every single error that resulted...

Some plugins do have the correct URL in the POM, but haven't been released yet, a few are simple URL typos, but the majority specify no wiki URL in the POM.

Ideally somebody would also now make pull requests for most of the plugins on the list...