### PR TITLE
Add more deprecated/renamed plugins to exclude from the Update Centre.

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -26,3 +26,16 @@ matrix-project-1.4.1      # this specific version is excluded for INFRA-250
 matrix-project-1.2.1      # also INFRA-250
 rtc                       # superseded by Team Concert Plugin
 HiddenParameter           # renamed to hidden-parameter
+sample                    # junk plugin; developer has been banned
+ChatRoom                  # junk plugin; developer has been banned
+mcap-eas-plugin           # superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
+Relution                  # renamed to relution-publisher
+rally-update-plugin-1     # renamed to rally-plugin(!)
+skytap-cloud-plugin       # renamed to skytap
+sonatype-ci               # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
+TestExecuter              # renamed to selected-tests-executor
+TestResultsAnalyzer       # renamed to test-results-analyzer
+jenkinswalldisplay-pom    # renamed to jenkinswalldisplay
+perfectomobile-jenkins    # renamed to perfectomobile
+paaslane                  # renamed to paaslane-estimate
+sms-notification          # renamed to sms


### PR DESCRIPTION
Related to #14, I went through the entire plugin list and went searching through artifact IDs, GitHub repos, old wiki pages and ended up with this list of (mostly) unreported artifact ID renames.

I still have a few more to look into more closely...