### PR TITLE
Exclude plugins without a valid wiki page from the Update Centre JSON files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,12 @@
       <artifactId>jetty-util</artifactId>
       <version>6.0.0rc1</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/org/jvnet/hudson/update_center/AlphaBetaOnlyRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/AlphaBetaOnlyRepository.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
@@ -24,7 +23,6 @@ import java.util.TreeMap;
  * @author Kohsuke Kawaguchi
  */
 public class AlphaBetaOnlyRepository extends MavenRepository {
-    private final MavenRepository base;
 
     /**
      * If true, negate the logic and only find non-alpha/beta releases.
@@ -32,7 +30,7 @@ public class AlphaBetaOnlyRepository extends MavenRepository {
     private boolean negative;
 
     public AlphaBetaOnlyRepository(MavenRepository base, boolean negative) {
-        this.base = base;
+        setBaseRepository(base);
         this.negative = negative;
     }
 

--- a/src/main/java/org/jvnet/hudson/update_center/LatestLinkBuilder.java
+++ b/src/main/java/org/jvnet/hudson/update_center/LatestLinkBuilder.java
@@ -18,6 +18,8 @@ public class LatestLinkBuilder implements Closeable {
     private final PrintWriter htaccess;
 
     public LatestLinkBuilder(File dir) throws IOException {
+        System.out.println(String.format("Writing plugin symlinks and redirects to dir: %s", dir));
+
         index = new IndexHtmlBuilder(dir,"Permalinks to latest files");
         htaccess = new PrintWriter(new FileWriter(new File(dir,".htaccess")),true);
 

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepository.java
@@ -72,7 +72,7 @@ public abstract class MavenRepository {
 
 
     /**
-     * Discover all hudson.war versions.
+     * Discover all hudson.war versions. Map must be sorted by version number, descending.
      */
     public abstract TreeMap<VersionNumber,HudsonWar> getHudsonWar() throws IOException, AbstractArtifactResolutionException;
 

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepository.java
@@ -20,6 +20,9 @@ import java.util.TreeMap;
  * @author Kohsuke Kawaguchi
  */
 public abstract class MavenRepository {
+
+    protected MavenRepository base;
+
     /**
      * Discover all plugins from this Maven repository.
      */
@@ -81,4 +84,15 @@ public abstract class MavenRepository {
     }
 
     protected abstract File resolve(ArtifactInfo a, String type, String classifier) throws AbstractArtifactResolutionException;
+
+    /** Should be called by subclasses who are decorating an existing MavenRepository instance. */
+    protected void setBaseRepository(MavenRepository base) {
+        this.base = base;
+    }
+
+    /** @return The base instance that this repository is wrapping; or {@code null} if this is the base instance. */
+    public MavenRepository getBaseRepository() {
+        return base;
+    }
+
 }

--- a/src/main/java/org/jvnet/hudson/update_center/TruncatedMavenRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/TruncatedMavenRepository.java
@@ -22,11 +22,10 @@ import java.util.TreeMap;
  * @author Kohsuke Kawaguchi
  */
 public class TruncatedMavenRepository extends MavenRepository {
-    private final MavenRepository base;
     private final int cap;
 
     public TruncatedMavenRepository(MavenRepository base, int cap) {
-        this.base = base;
+        setBaseRepository(base);
         this.cap = cap;
     }
 

--- a/src/main/java/org/jvnet/hudson/update_center/VersionCappedMavenRepository.java
+++ b/src/main/java/org/jvnet/hudson/update_center/VersionCappedMavenRepository.java
@@ -20,7 +20,6 @@ import java.util.TreeMap;
  * @author Kohsuke Kawaguchi
  */
 public class VersionCappedMavenRepository extends MavenRepository {
-    private final MavenRepository base;
 
     /**
      * Version number to cap. We only report plugins that are compatible with this core version.
@@ -33,7 +32,7 @@ public class VersionCappedMavenRepository extends MavenRepository {
     private final VersionNumber capCore;
 
     public VersionCappedMavenRepository(MavenRepository base, VersionNumber capPlugin, VersionNumber capCore) {
-        this.base = base;
+        setBaseRepository(base);
         this.capPlugin = capPlugin;
         this.capCore = capCore;
     }

--- a/src/test/java/org/jvnet/hudson/update_center/ConfluencePluginListTest.java
+++ b/src/test/java/org/jvnet/hudson/update_center/ConfluencePluginListTest.java
@@ -1,0 +1,109 @@
+package org.jvnet.hudson.update_center;
+
+import hudson.plugins.jira.soap.ConfluenceSoapService;
+import hudson.plugins.jira.soap.RemotePage;
+import hudson.plugins.jira.soap.RemotePageSummary;
+import junit.framework.TestCase;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConfluencePluginListTest extends TestCase {
+
+    private ConfluenceSoapService confluence;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        confluence = mock(ConfluenceSoapService.class);
+        when(confluence.getPage("", "JENKINS", "Plugins")).thenReturn(new RemotePage());
+    }
+
+    public void testUnknownUrlsAreIgnored() throws Exception {
+        // Given a list of plugin pages that exist on the wiki
+        addPluginPages(
+                "https://wiki.jenkins-ci.org/display/JENKINS/Foo+Plugin",
+                "https://wiki.jenkins-ci.org/display/JENKINS/Bar+Plugin"
+        );
+
+        // When we retrieve plugin info from Confluence
+        ConfluencePluginList pluginList = new ConfluencePluginList(confluence);
+
+        // Then we should not match URLs that don't exist on the wiki
+        assertNull(pluginList.resolveWikiUrl(""));
+        assertNull(pluginList.resolveWikiUrl(null));
+        assertNull(pluginList.resolveWikiUrl("https://github.com/jenkinsci/jenkins"));
+        assertNull(pluginList.resolveWikiUrl("https://wiki.jenkins-ci.org/display/JENKINS/Missing+Plugin"));
+
+        // And we should not match URLs with the wrong prefix
+        assertNull(pluginList.resolveWikiUrl("https://wiki.example.com/display/JENKINS/Foo+Plugin"));
+    }
+
+    public void testResolveCanonicalUrl() throws Exception {
+        // Given a list of plugin pages that exist on the wiki
+        addPluginPages(
+                "https://wiki.jenkins-ci.org/display/JENKINS/Foo+Plugin",
+                "https://wiki.jenkins-ci.org/display/JENKINS/Bar+Plugin"
+        );
+
+        // When we retrieve plugin info from Confluence
+        ConfluencePluginList pluginList = new ConfluencePluginList(confluence);
+
+        // Then we should get the canonical URL for items that can be found on the wiki
+        final String expected = "https://wiki.jenkins-ci.org/display/JENKINS/Foo+Plugin";
+        assertEquals(expected, pluginList.resolveWikiUrl("https://wiki.jenkins-ci.org/display/JENKINS/Foo+Plugin"));
+        assertEquals(expected, pluginList.resolveWikiUrl("http://wiki.jenkins-ci.org/display/JENKINS/Foo+Plugin"));
+        assertEquals(expected, pluginList.resolveWikiUrl("http://wiki.hudson-ci.org/display/JENKINS/Foo+Plugin"));
+        assertEquals(expected, pluginList.resolveWikiUrl("http://hudson.gotdns.com/wiki/display/JENKINS/Foo+Plugin"));
+    }
+
+    public void testUrlsWithEncoding() throws Exception {
+        // Given some URLs that have URL-encoded characters
+        addPluginPages(
+                "https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Speaks%21+Plugin",
+                "https://wiki.jenkins-ci.org/display/JENKINS/Plugin+Usage+Plugin+%28Community%29"
+        );
+
+        // When we retrieve plugin info from Confluence
+        ConfluencePluginList pluginList = new ConfluencePluginList(confluence);
+
+        // Then we should match POM URLs which may be differently encoded
+        assertNotNull(pluginList.resolveWikiUrl("http://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Speaks!+Plugin"));
+        assertNotNull(pluginList.resolveWikiUrl("http://wiki.jenkins-ci.org/display/JENKINS/Plugin+Usage+Plugin+(Community)"));
+    }
+
+    public void testUrlWithPageId() throws Exception {
+        // Given a wiki URL with a page ID, as Confluence doesn't like certain characters in wiki URLs
+        addPluginPages("https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=60915753");
+
+        // When we retrieve plugin info from the wiki
+        ConfluencePluginList pluginList = new ConfluencePluginList(confluence);
+
+        // Then the page should be found, even although it doesn't fit into the usual /display/JENKINS/<name> format
+        assertNotNull(pluginList.resolveWikiUrl("https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=60915753"));
+    }
+
+    public void testMalformedWikiUrls() throws Exception {
+        // Given a list of plugin pages that exist on the wiki
+        addPluginPages("https://wiki.jenkins-ci.org/display/JENKINS/Foo+Plugin");
+
+        // When we retrieve plugin info from Confluence
+        ConfluencePluginList pluginList = new ConfluencePluginList(confluence);
+
+        // Then we should reject bizarre URLs in the POM, but not crash
+        assertNull(pluginList.resolveWikiUrl("file:///etc/passwd"));
+        assertNull(pluginList.resolveWikiUrl("wiki.jenkins-ci.org/display/JENKINS/Foo+Plugin"));
+        assertNull(pluginList.resolveWikiUrl("https://wiki.jenkins-ci.org/display/JENKINS/Spaces in URL Plugin"));
+    }
+
+    /** Adds zero or more plugins to the "wiki". */
+    private void addPluginPages(String... urls) throws Exception {
+        RemotePageSummary[] pluginPages = new RemotePageSummary[urls.length];
+        for (int i = 0, n = urls.length; i < n; i++) {
+            pluginPages[i] = new RemotePageSummary(0, 0, "", "", urls[i], 0); // we only care about the page URL
+        }
+        when(confluence.getChildren(any(String.class), any(Long.class))).thenReturn(pluginPages);
+    }
+
+}


### PR DESCRIPTION
The criteria for inclusion are:
- Plugins must specify a Jenkins wiki URL in their `pom.xml`, via the `<url>` tag
- The wiki page must exist on the Jenkins wiki
- The wiki page must be a child of the "Plugins" page

Also accepted are:
- Wiki short URLs (e.g. `/x/GYCGAQ`)
- Wiki URLs with a numeric ID (e.g. `/pages/viewpage.action?pageId=60915753`)
- URLs which have legacy URL prefixes (e.g. non-HTTPS, wiki.hudson-ci.org)
- URLs ending with a trailing slash

Plugins not meeting these criteria will not be included in the Update Centre JSON file, or will have an empty `wiki` value in the release history JSON file.

As before, plugins may also be excluded via the `artifact-ignores.properties` file, or if a plugin does specify a valid wiki page, but that wiki page has the `plugin-deprecated` label.

While building the plugin list, more informational output is now printed to the console regarding why plugins are being excluded, or whether their wiki URL was rewritten to the canonical wiki URL format.

A summary of the total number of included, excluded and deprecated plugins is also shown at the end of building the Update Centre plugin list.

A number of test cases were added to test the basic URL resolution process, as well as some of the rarer types of URL found in currently-released plugins.

---

These changes are as agreed in the most recent community meeting (and broadly on the developers' mailing list).  This raises the quality bar a tiny bit to ensure plugins are at least minimally documented, and that users have a chance of seeing an excerpt in the Update Centre, and hopefully also source code links and JIRA info.

All current plugin releases which *do* have a wiki page, but *do not* list the URL in the POM have been grandfathered in via #14.

When running with `-no-experimental` (plus the overrides from #14, and the further exclusions from #19), this leaves **~~45~~ ~~38~~ 37 plugins** that would be excluded from the Update Centre, after this code is merged.  But the wiki overrides in #22 will provide a grace period for these plugins:

ID | POM URL
---|---
build-flow-toolbox-plugin | 
caliper-ci | https://code.google.com/p/caliper-ci/
chef | https://github.com/melezhik/chef-plugin
collabnet-automic-deploy | 
collabnet-uc4-deploy | 
ColumnsPlugin | http://wiki.jenkins-ci.org/display/JENKINS/ColumnPack+Plugin
cucumber | https://github.com/melezhik/cucumber-plugin
deploygate-plugin | 
devstack | https://wiki.jenkins-ci.org/display/JENKINS/Devstack+Plugin
DotCi | https://github.com/groupon/DotCi
DotCi-Fig-template | http://github.com/groupon/DotCi-Fig-template
DotCi-Plugins-Starter-Pack | https://github.com/groupon/DotCi-Plugins-Starter-Pack
drecycler | 
event-announcer | http://wiki.jenkins-ci.org/display/JENKINS/My+Plugin
flexteam | http://wiki.jenkins-ci.org/display/JENKINS/FlexTeam+Plugin
ikachan | https://wiki.jenkins-ci.org/display/JENKINS/Ikachan+Plugin
jackson-databind | 
jenkins-tracker | https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Tracker+Plugin
jprt | http://wiki.jenkins-ci.org/display/JENKINS/JPRT+Plugin
jsch | http://wiki.jenkins-ci.org/display/JENKINS/JSch+plugin
keep-slave-disconnected | 
monitor-remote-job | 
multiline-tabbar-plugin | http://wiki.hudson-ci.org/display/HUDSON/Extension+Point+for+Project+Views+Navigation
mysql-job-databases | https://github.com/codevise/jenkins-mysql-job-databases-plugin
network-monitor | http://wiki.jenkins-ci.org/display/JENKINS/Network+Monitor+Plugin
oki-docki | 
package-parameter | https://wiki.jenkins-ci.org/display/JENKINS/Package+Parameter+Plugin
perl | https://github.com/melezhik/perl-plugin
perl-smoke-test | https://github.com/melezhik/perl-smoke-test-plugin
rallyBuild | http://wiki.jenkins-ci.org/display/JENKINS/rallyBuild
sidebar-update-notification | 
sourcemonitor | http://wiki.jenkins-ci.org/display/JENKINS/SourceMonitor+Plugin
SSSCM | 
suite-test-groups-publisher | http://wiki.jenkins-ci.org/display/JENKINS/Suite+Test+Groups+Publisher
url-auth | https://github.com/kellyelton/url-auth-jenkins
writable-filesystem-monitor | 
zmq-event-publisher | https://github.com/cboylan/zmq-event-publisher

Usage stats for these plugins can be seen in the old list; only a few are really popular:
https://gist.github.com/orrc/2995a31028a27f9765d1

I know that a few of these are nothing to worry about:

ID | Comments
---|---
~~bees-sdk-plugin~~ | ~~ndeloof says this can be killed off~~
~~foofoo~~ | ~~Junk~~
~~hello-world~~ | ~~Junk~~
jprt | Looks to be very old; something to do with Sun?
~~koji-plugin~~ | ~~This is a bit complex; I've emailed the maintainer to work things out~~
multiline-tabbar-plugin | Some old Hudson plugin; is this [tab behaviour](https://wiki.jenkins-ci.org/display/JENKINS/Extension+Point+for+Project+Views+Navigation) now in core?
oki-docki | Waiting for a release of docker-custom-build-environment-plugin to supersede this

But the next step is to announce this on the mailing list and try and contact the maintainers of the remaining plugins — hopefully they can be found, and will add wiki pages for their plugins.

I would suggest adding additional, *temporary* wiki overrides (for ~3-6 months, as mentioned in the meeting) for these 45 plugins, pointing all of them to a "Plugin Page Missing" wiki page, which explains that there is no documentation, no infobox (so no source code link, no JIRA issues), and encourages people to find the maintainer and get them to add a wiki page.
Otherwise, after the deadline, the plugin will be excluded like other undocumented plugins.