### PR TITLE
Reinstate database-drizzle plugin, now that the UC can handle such URLs

### DIFF
--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -29,9 +29,6 @@ workflow-step-api=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
 workflow-stm=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
 workflow-support=https://wiki.jenkins-ci.org/display/JENKINS/Workflow+Plugin
 
-# Should remain commented out until pull #20 is merged, otherwise UC generation fails
-#database-drizzle=https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=65669136
-
 # Required until a new version with this URL in pom.xml is released
 additional-identities-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Additional+Identities+Plugin
 ApicaLoadtest=https://wiki.jenkins-ci.org/display/JENKINS/Apica+Loadtest+Plugin
@@ -44,6 +41,7 @@ cocoapods-integration=https://wiki.jenkins-ci.org/display/JENKINS/CocoaPods+Plug
 cucumber-reports=https://wiki.jenkins-ci.org/display/JENKINS/Cucumber+Reports+Plugin
 custom-view-tabs=https://wiki.jenkins-ci.org/display/JENKINS/Custom+View+Tabs+Plugin
 deployment-notification=https://wiki.jenkins-ci.org/display/JENKINS/Deployment+Notification+Plugin
+database-drizzle=https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=65669136
 diskcheck=https://wiki.jenkins-ci.org/display/JENKINS/DiskCheck+Plugin
 docker-build-publish=https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Build+and+Publish+plugin
 dynamicparameter=https://wiki.jenkins-ci.org/display/JENKINS/Dynamic+Parameter+Plug-in


### PR DESCRIPTION
**Must be merged _after_ PR 20 is merged**

Previously, we couldn't add this override, as the UC generator would crash when dealing with an override URL in this format.