### PR TITLE
Use the plugin name from each plugin's metadata, rather than wiki page titles

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -300,7 +300,6 @@ public class Main {
                     }
                 }
 
-                System.out.println("=> " + plugin.getTitle());
                 JSONObject json = plugin.toJSON();
                 System.out.println("=> " + json);
                 plugins.put(plugin.artifactId, json);
@@ -396,7 +395,7 @@ public class Main {
                 try {
                     Plugin plugin = new Plugin(h, cpl);
                     
-                    String title = plugin.getTitle();
+                    String title = plugin.getName();
                     if ((title==null) || (title.equals(""))) {
                         title = h.artifact.artifactId;
                     }

--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -297,17 +297,20 @@ public class Plugin {
     private static final Pattern HYPERLINK_PATTERN = Pattern.compile("\\[([^|\\]]+)\\|([^|\\]]+)(|([^]])+)?\\]");
     private static final Pattern NEWLINE_PATTERN = Pattern.compile("(?:\\r\\n|\\n)");
 
-    public String getTitle() {
-        String title = page != null ? page.getTitle() : null;
-        if ("Plugin Documentation Missing".equals(title)) {
-            // Don't overwrite the name just because the wiki page is missing.
-            // This code block can be removed once the associated wiki overrides are removed
-            title = null;
+    /** @return The plugin name defined in the POM &lt;name>; falls back to the wiki page title, then artifact ID. */
+    public String getName() {
+        String title = selectSingleValue(pom, "/project/name");
+        if (title == null && page != null) {
+            title = page.getTitle();
+            if ("Plugin Documentation Missing".equals(title)) {
+                // Don't overwrite the name just because the wiki page is missing.
+                // This code block can be removed once the associated wiki overrides are removed
+                title = null;
+            }
         }
-        if (title == null)
-            title = selectSingleValue(pom, "/project/name");
-        if (title == null)
+        if (title == null) {
             title = artifactId;
+        }
         return title;
     }
 
@@ -336,7 +339,7 @@ public class Plugin {
             json.put("previousTimestamp", fisheyeDateFormatter.format(previous.getTimestamp()));
         }
 
-        json.put("title", getTitle());
+        json.put("title", getName());
         if (page!=null) {
             json.put("wiki",page.getUrl());
             String excerpt = getExcerptInHTML();


### PR DESCRIPTION
Previously, if multiple plugins used the same wiki URL (e.g. workflow-*), then each of those plugins would use the same display name, leading to confusion when users saw multiple plugins with the same title in the Plugin Manager.

Now we use the name defined in the plugin metadata (e.g. POM `<name>`), and fall back to the wiki page title if that metadata is missing.  If the wiki page is missing or failed to be downloaded, we then fall back to using the artifact ID.