### PR TITLE
Remove the closed-source Antepedia Reporter plugin.

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -66,3 +66,4 @@ bees-sdk-plugin           # removal requested by ndeloof: RUN@cloud service no l
 koji-plugin               # renamed to koji
 rally-bookkeeper          # removal requested by Mike Rogers: will be Rally plugin 2.0
 ssh2easy-plugin           # removal requested by plugin author, accidental rename
+AntepediaReporter-CI-plugin # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau


### PR DESCRIPTION
After discussion with the owner regarding the Jenkins project policy of only hosting open source plugins, they requested removal of this plugin.
They'll create a new, open source plugin at some point in the future.