### PR TITLE
Exclude datadog-build-reporter from Update Center

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -67,6 +67,7 @@ koji-plugin               # renamed to koji
 rally-bookkeeper          # removal requested by Mike Rogers: will be Rally plugin 2.0
 ssh2easy-plugin           # removal requested by plugin author, accidental rename
 AntepediaReporter-CI-plugin # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
+datadog-build-reporter    # renamed to datadog
 
 # broken releases, hpi/jpi does not exist or is not a zip file, resulting in maven errors
 accurev-0.6.28


### PR DESCRIPTION
Renamed the plugin to datadog