### PR TITLE
Revert "Fixed at least since 0.7.14"

### DIFF
--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -56,4 +56,5 @@ svn-workspace-cleaner=https://wiki.jenkins-ci.org/display/JENKINS/SVN+Workspace+
 text-finder-run-condition=https://wiki.jenkins-ci.org/display/JENKINS/Text+Finder+Run+Condition+Plugin
 unicorn=http://wiki.jenkins-ci.org/display/JENKINS/Unicorn+Validation+Plugin
 vaddy-plugin=https://wiki.jenkins-ci.org/display/JENKINS/VAddy+Plugin
+violations=https://wiki.jenkins-ci.org/display/JENKINS/Violations
 xpdev=https://wiki.jenkins-ci.org/display/JENKINS/XP-Dev+Plugin


### PR DESCRIPTION
Followup to the IRC discussion. Just in case. Also sent a heads up to the [current maintainer since last june](https://groups.google.com/forum/#!topic/jenkinsci-dev/mWUgOZc61KY) (@tomasbjerre)

Actually, the 0.7.14 was seemingly borked. It's only present in SCM, but
latest deployed is 0.7.11 on the maven repository...

This reverts commit 0eba8aa485c1cd689d9f1114255c806d564dc637.