### PR TITLE
Create a 1.642.x-specific site

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -43,7 +43,7 @@ echo '<?php $rules = array( ' > "$RULE"
 
 # make sure the latest baseline version here is available as LTS and in the Maven index of the repo, 
 # otherwise it'll offer the weekly as update to a running LTS version
-declare -a baselines=( 1.554 1.565 1.580 1.596 1.609 1.625 )
+declare -a baselines=( 1.554 1.565 1.580 1.596 1.609 1.625 1.642 )
 
 for v in ${baselines[@]}; do
     # for mainline up to $v, which advertises the latest core


### PR DESCRIPTION
For example I have some changes prepared for `workflow-plugin` which require baselines after 1.625 (but before 1.642). I think this is the magic incantation.

@reviewbybees