### PR TITLE
Add wiki override for the Play Framework plugin.

### DIFF
--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -40,6 +40,7 @@ mansion-cloud=https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connec
 openJDK-native-plugin=https://wiki.jenkins-ci.org/display/JENKINS/OpenJDK+native+installer+plugin
 periodicbackup=https://wiki.jenkins-ci.org/display/JENKINS/PeriodicBackup+Plugin
 php=https://wiki.jenkins-ci.org/display/JENKINS/PHP+Plugin
+play-autotest-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Play%21+Framework+Plugin
 ## Sources are not under jenkinsci, but at https://bitbucket.org/henriklynggaard/prereq-buildstep-plugin/
 prereq-buildstep=http://wiki.jenkins-ci.org/display/JENKINS/Prerequisite+build+step+plugin
 ## Sources are not under jenkinsci, but at https://bitbucket.org/henriklynggaard/project-health-report-plugin/


### PR DESCRIPTION
Its wiki page was renamed without updating the POM and fell victim to [INFRA-301](https://issues.jenkins-ci.org/browse/INFRA-301).

This isn't really the plugin developer's fault, so we can add a temporary override.

Mailing list thread: https://groups.google.com/d/msg/jenkinsci-users/N3D0ceIor5M/PL61zc3IHAAJ