### PR TITLE
Update urls to use a secure connection.

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -12,7 +12,7 @@ mvn -e clean install
 function generate() {
     java -jar target/update-center2-*-bin*/update-center2-*.jar \
       -id default \
-      -connectionCheckUrl http://www.google.com/ \
+      -connectionCheckUrl https://www.google.com/ \
       -key $SECRET/update-center.key \
       -certificate $SECRET/update-center.cert \
       "$@"

--- a/src/main/java/org/jvnet/hudson/update_center/HPI.java
+++ b/src/main/java/org/jvnet/hudson/update_center/HPI.java
@@ -58,7 +58,7 @@ public class HPI extends MavenArtifact {
      * Download a plugin via more intuitive URL. This also helps us track download counts.
      */
     public URL getURL() throws MalformedURLException {
-        return new URL("http://updates.jenkins-ci.org/download/plugins/"+artifact.artifactId+"/"+version+"/"+artifact.artifactId+".hpi");
+        return new URL("https://updates.jenkins-ci.org/download/plugins/"+artifact.artifactId+"/"+version+"/"+artifact.artifactId+".hpi");
     }
 
     /**

--- a/src/main/java/org/jvnet/hudson/update_center/HudsonWar.java
+++ b/src/main/java/org/jvnet/hudson/update_center/HudsonWar.java
@@ -39,7 +39,7 @@ public class HudsonWar extends MavenArtifact {
 
     @Override
     public URL getURL() throws MalformedURLException {
-        return new URL("http://updates.jenkins-ci.org/download/war/"+version+"/"+ getFileName());
+        return new URL("https://updates.jenkins-ci.org/download/war/"+version+"/"+ getFileName());
     }
 
     /**


### PR DESCRIPTION
Providing secure urls will enable jenkins installations that are installed behind a firewall that blocks outgoing requests on port 80 to use the update center. 

This is also relevant because the actual `update-center.json` by default in jenkins are requested through `https`.