### PR TITLE
Blacklist poll-mailbox-trigger, due to rename.

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -69,6 +69,7 @@ ssh2easy-plugin           # removal requested by plugin author, accidental renam
 AntepediaReporter-CI-plugin # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
 datadog-build-reporter    # renamed to datadog
 fortify-on-demand-uploader-1.0 # removal requested by Ryan Black, plugin wasn't ready for release
+poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
As requested on the jenkins-infra mailing list by the plugin author.

`post-mailbox-trigger` was renamed to `post-mailbox-trigger-plugin`.

While the old artifact ID doesn't appear in most Update Centres because it has an invalid wiki URL, it still appears in LTS UCs as the wiki rule is ignored for them.