### PR TITLE
Remove octoperf-jenkins-plugin

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -70,6 +70,7 @@ AntepediaReporter-CI-plugin # closed-souce plugin; removal confirmed with owner,
 datadog-build-reporter    # renamed to datadog
 fortify-on-demand-uploader-1.0 # removal requested by Ryan Black, plugin wasn't ready for release
 poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
+octoperf-jenkins-plugin   # released from wrong repository; will be renamed
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
As discussed here:
https://issues.jenkins-ci.org/browse/HOSTING-35

Removing the badly named plugin. It has also been released from wrong github repository.