### PR TITLE
Code quality fix - Classes and methods that rely on the default system encoding should not be used. 

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/IndexHtmlBuilder.java
+++ b/src/main/java/org/jvnet/hudson/update_center/IndexHtmlBuilder.java
@@ -24,7 +24,9 @@
 package org.jvnet.hudson.update_center;
 
 import java.io.Closeable;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -48,7 +50,7 @@ public class IndexHtmlBuilder implements Closeable {
         if (dir==null)  return new PrintWriter(new ByteArrayOutputStream()); // ignore output
         
         dir.mkdirs();
-        return new PrintWriter(new FileWriter(new File(dir,"index.html")));
+        return new PrintWriter(new OutputStreamWriter(new FileOutputStream(new File(dir,"index.html")), "UTF-8"));
     }
 
     public IndexHtmlBuilder(PrintWriter out, String title) {

--- a/src/main/java/org/jvnet/hudson/update_center/LatestLinkBuilder.java
+++ b/src/main/java/org/jvnet/hudson/update_center/LatestLinkBuilder.java
@@ -2,8 +2,10 @@ package org.jvnet.hudson.update_center;
 
 import java.io.Closeable;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
 /**
@@ -21,7 +23,7 @@ public class LatestLinkBuilder implements Closeable {
         System.out.println(String.format("Writing plugin symlinks and redirects to dir: %s", dir));
 
         index = new IndexHtmlBuilder(dir,"Permalinks to latest files");
-        htaccess = new PrintWriter(new FileWriter(new File(dir,".htaccess")),true);
+        htaccess = new PrintWriter(new OutputStreamWriter(new FileOutputStream(new File(dir,".htaccess"), true), "UTF-8"));
 
         htaccess.println("# GENERATED. DO NOT MODIFY.");
         // Redirect directive doesn't let us write redirect rules relative to the directory .htaccess exists,

--- a/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenArtifact.java
@@ -130,7 +130,7 @@ public class MavenArtifact {
             while ((len=fin.read(buf,0,buf.length))>=0)
                 sig.update(buf,0,len);
 
-            return new String(Base64.encodeBase64(sig.digest()));
+            return new String(Base64.encodeBase64(sig.digest()), "UTF-8");
         } catch (NoSuchAlgorithmException e) {
             throw new IOException(e);
         }

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -161,7 +161,7 @@ public class MavenRepositoryImpl extends MavenRepository {
 
         URLConnection con = url.openConnection();
         if (url.getUserInfo()!=null) {
-            con.setRequestProperty("Authorization","Basic "+new sun.misc.BASE64Encoder().encode(url.getUserInfo().getBytes()));
+            con.setRequestProperty("Authorization","Basic "+new sun.misc.BASE64Encoder().encode(url.getUserInfo().getBytes("UTF-8")));
         }
 
         if (!expanded.exists() || !local.exists() || (local.lastModified()!=con.getLastModified() && !offlineIndex)) {

--- a/src/main/java/org/jvnet/hudson/update_center/Signer.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Signer.java
@@ -123,7 +123,7 @@ public class Signer {
         // and certificate chain
         JSONArray a = new JSONArray();
         for (X509Certificate cert : certs)
-            a.add(new String(Base64.encodeBase64(cert.getEncoded())));
+            a.add(new String(Base64.encodeBase64(cert.getEncoded()), "UTF-8"));
         sign.put("certificates",a);
 
         o.put("signature",sign);
@@ -165,11 +165,11 @@ public class Signer {
         public void addRecord(JSONObject sign, String prefix) throws GeneralSecurityException, IOException {
             // digest
             byte[] digest = sha1.digest();
-            sign.put(prefix+"digest",new String(Base64.encodeBase64(digest)));
+            sign.put(prefix+"digest",new String(Base64.encodeBase64(digest), "UTF-8"));
 
             // signature
             byte[] s = sig.sign();
-            sign.put(prefix+"signature",new String(Base64.encodeBase64(s)));
+            sign.put(prefix+"signature",new String(Base64.encodeBase64(s), "UTF-8"));
 
             // did the signature validate?
             if (!verifier.verify(s))


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
 
Please let me know if you have any questions.

Faisal Hameed