### PR TITLE
General code quality fix-1

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/DefaultMavenRepositoryBuilder.java
+++ b/src/main/java/org/jvnet/hudson/update_center/DefaultMavenRepositoryBuilder.java
@@ -26,6 +26,11 @@ package org.jvnet.hudson.update_center;
 import java.net.URL;
 
 public class DefaultMavenRepositoryBuilder {
+    
+    private DefaultMavenRepositoryBuilder () {
+        
+    }
+    
     public static MavenRepositoryImpl createStandardInstance() throws Exception {
         MavenRepositoryImpl instance = new MavenRepositoryImpl();
         instance.addRemoteRepository("public", new URL("http://repo.jenkins-ci.org/public/"));

--- a/src/main/java/org/jvnet/hudson/update_center/HPI.java
+++ b/src/main/java/org/jvnet/hudson/update_center/HPI.java
@@ -72,6 +72,7 @@ public class HPI extends MavenArtifact {
      * @deprecated
      *      Most probably you should be using {@link #getRequiredJenkinsVersion()}
      */
+    @Deprecated
     public String getRequiredHudsonVersion() throws IOException {
         return getManifestAttributes().getValue("Hudson-Version");
     }

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -132,7 +132,7 @@ public class Main {
     @Option(name="-skip-release-history",usage="Skip generation of release history")
     public boolean skipReleaseHistory;
 
-    public Signer signer = new Signer();
+    private Signer signer = new Signer();
 
     public static final String EOL = System.getProperty("line.separator");
 

--- a/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
+++ b/src/main/java/org/jvnet/hudson/update_center/MavenRepositoryImpl.java
@@ -253,8 +253,10 @@ public class MavenRepositoryImpl extends MavenRepository {
             }
 
             PluginHistory p = plugins.get(a.artifactId);
-            if (p==null)
-                plugins.put(a.artifactId, p=new PluginHistory(a.artifactId));
+            if (p==null) {
+                p=new PluginHistory(a.artifactId);
+                plugins.put(a.artifactId, p);
+            }
             p.addArtifact(createHpiArtifact(a, p));
             p.groupId.add(a.groupId);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1118 - Utility classes should not have public constructors.
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:AssignmentInSubExpressionCheck - Assignments should not be made from within sub-expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:AssignmentInSubExpressionCheck
 
Please let me know if you have any questions.

Faisal Hameed