### PR TITLE
General code quality fix-2

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/DefaultArtifactTransformationManager.java
+++ b/src/main/java/org/jvnet/hudson/update_center/DefaultArtifactTransformationManager.java
@@ -45,7 +45,7 @@ public class DefaultArtifactTransformationManager
 	public void initialize() throws InitializationException {
 		// TODO this is a hack until plexus can fix the ordering of the arrays
         artifactTransformations = new ArrayList(artifactTransformations);
-		Object obj[] = artifactTransformations.toArray();
+		Object[] obj = artifactTransformations.toArray();
 		for (int x = 0; x < obj.length; x++)
 		{
 			if (obj[x].getClass().getName().indexOf("Snapshot") != -1) {

--- a/src/main/java/org/jvnet/hudson/update_center/HPI.java
+++ b/src/main/java/org/jvnet/hudson/update_center/HPI.java
@@ -156,16 +156,16 @@ public class HPI extends MavenArtifact {
         public final boolean optional;
 
         public Dependency(String token) {
-            this.optional = token.endsWith(OPTIONAL);
+            this.optional = token.endsWith(OPTIONAL_RESOLUTION);
             if(optional)
-                token = token.substring(0, token.length()-OPTIONAL.length());
+                token = token.substring(0, token.length()-OPTIONAL_RESOLUTION.length());
 
             String[] pieces = token.split(":");
             name = pieces[0];
             version = pieces[1];
         }
 
-        private static final String OPTIONAL = ";resolution:=optional";
+        private static final String OPTIONAL_RESOLUTION = ";resolution:=optional";
 
         public JSONObject toJSON() {
             JSONObject o = new JSONObject();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1845 - Methods and field names should not be the same or differ only by capitalization.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1845

Please let me know if you have any questions.

Faisal Hameed