### PR TITLE
Update to jdk8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,13 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.26</version>
+    <version>1.35</version>
   </parent>
   <artifactId>update-center2</artifactId>
   


### PR DESCRIPTION
Note that this PR must **NOT** be merged as-is. It requires changing at least https://ci.jenkins-ci.org/job/Update%20Center/job/infra_update_center_v3/ from JDK7 to JDK8.

Will make doing good changes like https://github.com/jenkinsci/backend-update-center2/pull/44 possible in the future.

As @orrc asked on IRC, do we even have JDK8 available as installable tool on ci.j.o?

Ping @rtyler especially for the tooling part on ci.j.o
Ping also @daniel-beck 

Btw, maybe the next step could/should be creating a `Jenkinsfile` for that build+run, + potentially merging the -mirror downstream job into only one? Can work on that one too if you agree this would be a good thing.

Thanks