### PR TITLE
Revert "Hide unknown plugin flyway-runner"

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -80,7 +80,6 @@ ez-templates-1.0.2
 ez-templates-1.0.3
 ez-templates-1.0.4
 ez-templates-1.0.5
-flyway-runner
 
 # broken releases, hpi/jpi does not exist or is not a zip file, resulting in maven errors
 accurev-0.6.28


### PR DESCRIPTION
Plugin has now been officially forked under the jenkinsci organization.

Reverts jenkinsci/backend-update-center2#51

See also https://github.com/jenkinsci/backend-update-center2/pull/51#issuecomment-200705467