### PR TITLE
Remove rogue plugin release: jsontrigger.

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -80,6 +80,7 @@ ez-templates-1.0.2
 ez-templates-1.0.3
 ez-templates-1.0.4
 ez-templates-1.0.5
+jsontrigger               # not forked to jenkinsci; released without hosting request
 
 # broken releases, hpi/jpi does not exist or is not a zip file, resulting in maven errors
 accurev-0.6.28


### PR DESCRIPTION
Source code _appears_ to be here: https://github.com/dsrowell/jsontrigger-jenkins-plugin

But no hosting request (AFAICT), no wiki page, and no fork to jenkinsci, so they should disappear from the update centre.