### PR TITLE
Offer 2.x releases on experimental and latest update sites

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -64,12 +64,12 @@ done
 #     with symlinks pointing to the 'latest' current versions. So we generate exprimental first, then overwrite current to produce proper symlinks
 
 # experimental update center. this is not a part of the version-based redirection rules
-generate -skip-release-history -capCore 1.999 -www ./www2/experimental -download ./download
+generate -skip-release-history -www ./www2/experimental -download ./download
 
 # for the latest without any cap
 # also use this to generae https://updates.jenkins-ci.org/download layout, since this generator run
 # will capture every plugin and every core
-generate -no-experimental -capCore 1.999 -www ./www2/current -www-download ./www2/download -download ./download -pluginCount.txt ./www2/pluginCount.txt
+generate -no-experimental -www ./www2/current -www-download ./www2/download -download ./download -pluginCount.txt ./www2/pluginCount.txt
 
 echo "); ?>" >> "$RULE"
 


### PR DESCRIPTION
**To be merged only once 2.0 has been released and is available on the update center.**

This effectively reverts c1f19d787fd56fe574841bdc6d6925ab4cdddab2, but does not revert feb8a9b156098b8307b31201150ab5e03cd02b7b. I am proposing to stage the 2.0 rollout. People on versions older than a few weeks will unlikely be interested in updating immediately anyway.