### PR TITLE
Deprecate blackduck-installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 www
 .htaccess
 .idea
+/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ target
 www
 .htaccess
 .idea
-/bin/

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -72,7 +72,6 @@ fortify-on-demand-uploader-1.0 # removal requested by Ryan Black, plugin wasn't 
 poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
 octoperf-jenkins-plugin   # released from wrong repository; will be renamed
 upload-artifacts-to-nexus # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
-blackduck-installer		  # deprecated
 
 # rogue releases with unknown source
 ez-templates-1.0.0

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -72,6 +72,7 @@ fortify-on-demand-uploader-1.0 # removal requested by Ryan Black, plugin wasn't 
 poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
 octoperf-jenkins-plugin   # released from wrong repository; will be renamed
 upload-artifacts-to-nexus # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
+blackduck-installer		  # deprecated
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
We are no longer supporting this plugin and it does not work with the current version of the update-sites-manager plugin, so we would like to remove it from the list of available plugins