### PR TITLE
Active Directory 1.44 is broken

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -98,3 +98,4 @@ vncrecorder-1.9
 warnings-4.29
 warnings-4.30
 warnings-4.31
+active-directory-1.44


### PR DESCRIPTION
Active Directory plugin 1.44 is broken. See: [JENKINS-34426](https://issues.jenkins-ci.org/browse/JENKINS-34426)

I currently have the fix [here](https://github.com/jenkinsci/active-directory-plugin/pull/32) and have the confirmation from the person who opened the Jira issue that it is happening. I am waiting for review.

I think we should hide the broken version

@reviewbybees