### PR TITLE
Suppress accidental Checkmarx release

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -98,3 +98,7 @@ vncrecorder-1.9
 warnings-4.29
 warnings-4.30
 warnings-4.31
+
+# Suppress accidental release
+checkmarx-8.1.0
+


### PR DESCRIPTION
The plugin version was released too soon and we want to remove it for now.