### PR TITLE
Adds an option to just verify that a plugin would be included.

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -352,12 +352,20 @@ public class Main {
         System.out.println("Excluded " + deprecatedCount + " plugins marked as deprecated on the wiki.");
         System.out.println("Excluded " + missingWikiUrlCount + " plugins without a valid wiki URL.");
 
-        // If we are verifying a plugin string, check whether the missing wiki URL count is greater than 0.
-        if (verifyPluginStr != null && missingWikiUrlCount > 0) {
-            // If so, notify the user and exit out with an exit code of 1.
-            System.out.println("ERROR IN VERIFICATION: " + missingWikiUrlCount + " plugins found matching string "
-                    + "but without valid wiki URLs.");
-            System.exit(1);
+        // If we're verifying a plugin string, check if the counts match expectations.
+        if (verifyPluginStr != null) {
+            // If no plugins, valid, invalid or deprecated, were found matching the string, exit out.
+            if (validCount == 0 && deprecatedCount == 0 && missingWikiUrlCount == 0) {
+                System.out.println("ERROR IN VERIFICATION: No plugins found matching string '" + verifyPluginStr + "'");
+                System.exit(1);
+            }
+            // If the missing wiki URL count is greater than 0, exit out.
+            else if (missingWikiUrlCount > 0) {
+                System.out.println("ERROR IN VERIFICATION: " + missingWikiUrlCount + " plugins found matching string '"
+                        + verifyPluginStr + "' but without valid wiki URLs.");
+                System.exit(1);
+            }
+            // Otherwise, we're all good and will just continue as normal.
         }
 
         return plugins;


### PR DESCRIPTION
Given the argument "-verify-plugin someString", no files will actually
be written, core won't be processed, and only plugins containing
'someString' will be processed. This can be used to verify whether a
plugin release has a valid wiki page and meets any other criteria we
may add in the future.

Usage:

- mvn clean install
- java -jar target/update-center2-*-bin*/update-center2-*.jar \
    -id testing -verify-plugin github-branch-source

If any plugins matching the -verify-plugin string are found but don't
have valid wiki pages (currently that's the only thing we check
against, but if we add further criteria in the future, we'll check
those too), the script will notify the user and exit out with an exit
code of 1.

cc @rtyler @kohsuke @orrc @batmat 