### PR TITLE
Add wiki override for absint-astree.

### DIFF
--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -61,3 +61,6 @@ unicorn=http://wiki.jenkins-ci.org/display/JENKINS/Unicorn+Validation+Plugin
 vaddy-plugin=https://wiki.jenkins-ci.org/display/JENKINS/VAddy+Plugin
 violations=https://wiki.jenkins-ci.org/display/JENKINS/Violations
 xpdev=https://wiki.jenkins-ci.org/display/JENKINS/XP-Dev+Plugin
+
+# Workaround for INFRA-922
+absint-astree=https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=99910545


### PR DESCRIPTION
Required as a workaround for [INFRA-922](https://issues.jenkins-ci.org/browse/INFRA-922).