### PR TITLE
Don't checksum plugin releases

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -118,7 +118,7 @@ popd
 
 # push plugins to mirrors.jenkins-ci.org
 chmod -R a+r download
-rsync -acvz download/plugins/ ${RSYNC_USER}@${UPDATES_SITE}:/srv/releases/jenkins/plugins
+rsync -avz --size-only download/plugins/ ${RSYNC_USER}@${UPDATES_SITE}:/srv/releases/jenkins/plugins
 
 # push generated index to the production servers
 # 'updates' come from tool installer generator, so leave that alone, but otherwise


### PR DESCRIPTION
We don't allow replacing existing releases anyway. Also, skip the time comparison, as its uselessness is the reason we checksummed in the first place.

Further rationale, a recent update center generation build log (excerpt of "milestone" lines):

	16:01:10  Started by timer
	16:01:17  [INFO] Building Update center generator for jenkins-ci.org 1.21-SNAPSHOT
	16:01:30  [INFO] BUILD SUCCESS
	16:01:30  + java -jar … -www ./www2/1.554 -cap 1.554.999
	16:04:57  + java -jar … -www ./www2/stable-1.554 -cap 1.554.999 -capCore 2.7.999
	16:05:19  + java -jar … -www ./www2/1.565 -cap 1.565.999
	16:05:39  + java -jar … -www ./www2/stable-1.565 -cap 1.565.999 -capCore 2.7.999
	16:05:58  + java -jar … -www ./www2/1.580 -cap 1.580.999
	16:06:21  + java -jar … -www ./www2/stable-1.580 -cap 1.580.999 -capCore 2.7.999
	16:06:41  + java -jar … -www ./www2/1.596 -cap 1.596.999
	16:07:03  + java -jar … -www ./www2/stable-1.596 -cap 1.596.999 -capCore 2.7.999
	16:07:23  + java -jar … -www ./www2/1.609 -cap 1.609.999
	16:07:46  + java -jar … -www ./www2/stable-1.609 -cap 1.609.999 -capCore 2.7.999
	16:08:07  + java -jar … -www ./www2/1.625 -cap 1.625.999
	16:08:31  + java -jar … -www ./www2/stable-1.625 -cap 1.625.999 -capCore 2.7.999
	16:08:52  + java -jar … -www ./www2/1.642 -cap 1.642.999
	16:09:14  + java -jar … -www ./www2/stable-1.642 -cap 1.642.999 -capCore 2.7.999
	16:09:36  + java -jar … -www ./www2/1.651 -cap 1.651.999
	16:09:58  + java -jar … -www ./www2/stable-1.651 -cap 1.651.999 -capCore 2.7.999
	16:10:20  + java -jar … -www ./www2/2.7 -cap 2.7.999
	16:10:42  + java -jar … -www ./www2/stable-2.7 -cap 2.7.999 -capCore 2.7.999
	16:11:04  + java -jar … -skip-release-history -www ./www2/experimental -download ./download
	16:11:28  + java -jar … -www ./www2/current -www-download ./www2/download -download ./download -pluginCount.txt ./www2/pluginCount.txt
	16:12:15  sending incremental file list
	16:12:15  + rsync -acvz download/plugins/ www-data@updates.jenkins.io:/srv/releases/jenkins/plugins
	16:48:42  + rsync -acvz www2/ --exclude=/updates --delete www-data@updates.jenkins.io:/var/www/updates.jenkins.io
	16:48:52  Archiving artifacts
	16:48:55  Finished: SUCCESS
