### PR TITLE
Somebody pointed out that now we have .json and .js backward

### DIFF
--- a/site/generate.sh
+++ b/site/generate.sh
@@ -102,7 +102,7 @@ ln -sf ../updates ./www2/current/updates
 # generate symlinks to retain compatibility with past layout and make Apache index useful
 pushd www2
     ln -s stable-$lastLTS stable
-    for f in latest latestCore.txt release-history.json update-center.json update-center.json.html; do
+    for f in latest latestCore.txt release-history.json update-center.*; do
         ln -s current/$f .
     done
 

--- a/src/main/java/org/jvnet/hudson/update_center/Main.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Main.java
@@ -168,7 +168,7 @@ public class Main {
     }
 
     private void prepareStandardDirectoryLayout() {
-        json = new File(www,"update-center.js");
+        json = new File(www,"update-center.actual.json");
         jsonp = new File(www,"update-center.json");
         latest = new File(www,"latest");
         indexHtml = new File(www,"index.html");


### PR DESCRIPTION
but we have to keep `update-center.json` for JSONP, so JSON version needs another name