### PR TITLE
Remove now-redundant wiki override for gerrit-verify-status-reporter.

### DIFF
--- a/src/main/resources/wiki-overrides.properties
+++ b/src/main/resources/wiki-overrides.properties
@@ -4,9 +4,6 @@
 # Required until a newer version than 1.1 is released
 archived-artifact-url-viewer=https://wiki.jenkins-ci.org/display/JENKINS/Archived+Artifact+Url+Viewer+PlugIn
 
-# Required until a newer version than 0.0.2
-gerrit-verify-status-reporter=https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Verify+Status+Reporter+Plugin
-
 # Required until a newer version than 0.3 is released
 plugin-usage-plugin=https://wiki.jenkins-ci.org/display/JENKINS/Plugin+Usage+Plugin+(Community)
 


### PR DESCRIPTION
Maintainer made a new release with the correct wiki URL.