### PR TITLE
Suppress active-choices 1.5 and 1.5.0

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -107,3 +107,6 @@ gitlab-hook-1.4.1
 # Suppress accidental release
 checkmarx-8.1.0
 
+# Suppress a release with regression that can delete Groovy scripts (JENKINS-39620)
+uno-choice-1.5
+uno-choice-1.5.0


### PR DESCRIPTION
Hi, due to a regression in the plug-in, the Groovy script used for active-choices parameters is not being persisted after saving the job. This can cause users to lose their scripts after installing this version of the plug-in.

Thanks
Bruno