### PR TITLE
Suppress scm-api 2.0 due to dependent plugins breaking

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -110,3 +110,6 @@ checkmarx-8.1.0
 # Suppress a release with regression that can delete Groovy scripts (JENKINS-39620)
 uno-choice-1.5
 uno-choice-1.5.0
+
+# Suppress release while dependent components have not been updated
+scm-api-2.0


### PR DESCRIPTION
Apparently dependent plugins are breaking as this has been released before they were finished being adapted. @rtyler and @i386 are reporting problems in their instances.

@jglick @stephenc