### PR TITLE
Revert "Escape plugin title"

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Plugin.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Plugin.java
@@ -316,10 +316,6 @@ public class Plugin {
         if (title == null) {
             title = artifactId;
         }
-
-        // escape malicious HTML
-        title = StringEscapeUtils.escapeHtml(title);
-
         return title;
     }
 


### PR DESCRIPTION
This reverts commit 1b685b8d7b8d077ff40f943c22a30b0529143aae.

Turns out it wasn't necessary after all, see #92.