### PR TITLE
[INFRA-1024] Reduce required validity to 15 days

### DIFF
--- a/src/main/java/org/jvnet/hudson/update_center/Signer.java
+++ b/src/main/java/org/jvnet/hudson/update_center/Signer.java
@@ -188,7 +188,7 @@ public class Signer {
         List<X509Certificate> certs = new ArrayList<X509Certificate>();
         for (File f : certificates) {
             X509Certificate c = loadCertificate(cf, f);
-            c.checkValidity(new Date(System.currentTimeMillis()+ TimeUnit.DAYS.toMillis(30)));
+            c.checkValidity(new Date(System.currentTimeMillis()+ TimeUnit.DAYS.toMillis(15)));
             certs.add(c);
         }
 


### PR DESCRIPTION
Temporary measure to restore update site generation. To be reverted once we have a new cert.