### PR TITLE
Ignore SCM API 2.0 related changes until JENKINS-41121 is addressed

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -121,13 +121,13 @@ hello-world-scala
 
 # Suppress potentially harmful upgrades related to SCM API (JENKINS-41121)
 # Erring on the side of extreme caution until the fallout is resolved here
-scm-api:2.0.0
-scm-api:2.0.1
-branch-api:2.0.0
-github-branch-source:2.0.0
-cloudbees-bitbucket-branch-source:2.0.0
-github-organization-folder:1.6
-mercurial:1.58
-git:2.6.2
-git:3.0.2
-git:3.0.3
+scm-api-2.0.0
+scm-api-2.0.1
+branch-api-2.0.0
+github-branch-source-2.0.0
+cloudbees-bitbucket-branch-source-2.0.0
+github-organization-folder-1.6
+mercurial-1.58
+git-2.6.2
+git-3.0.2
+git-3.0.3

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -118,3 +118,16 @@ scm-api-2.0
 # Suppress Scala Hello World Plugin (HOSTING-235)
 hello-world-scala
 
+
+# Suppress potentially harmful upgrades related to SCM API (JENKINS-41121)
+# Erring on the side of extreme caution until the fallout is resolved here
+scm-api:2.0.0
+scm-api:2.0.1
+branch-api:2.0.0
+github-branch-source:2.0.0
+cloudbees-bitbucket-branch-source:2.0.0
+github-organization-folder:1.6
+mercurial:1.58
+git:2.6.2
+git:3.0.2
+git:3.0.3

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -124,6 +124,7 @@ hello-world-scala
 scm-api-2.0.0
 scm-api-2.0.1
 branch-api-2.0.0
+branch-api-2.0.1
 github-branch-source-2.0.0
 cloudbees-bitbucket-branch-source-2.0.0
 github-organization-folder-1.6
@@ -131,3 +132,5 @@ mercurial-1.58
 git-2.6.2
 git-3.0.2
 git-3.0.3
+workflow-multibranch-2.10
+pipeline-github-lib-1.0


### PR DESCRIPTION
The basic idea of this is that the upgrades are sufficiently dangerous and *one
direction* (i.e. no rollback except for restoring from a pre-upgrade backup of
JENKINS_HOME) that it's best for Jenkins users to hide these versions until this
is figured out and made more safe.


FYI @michaelneale @vivek  @i386


See https://jenkins.io/blog/2017/01/17/scm-api-2/ for the list of affected
plugins.