### PR TITLE
do not distribute ruby-runtime 0.13

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -75,6 +75,7 @@ upload-artifacts-to-nexus # renamed, see https://issues.jenkins-ci.org/browse/HO
 blackduck-installer		  # deprecated
 jbehave-hudson-plugin   # renamed to jbehave-jenkins-plugin
 kanboard-publisher        # renamed to kanboard, see https://issues.jenkins-ci.org/browse/HOSTING-241?focusedCommentId=280720&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280720
+ruby-runtime-0.13         # JENKINS-37353, JENKINS-37771 and JENKINS-38145
 
 # rogue releases with unknown source
 ez-templates-1.0.0


### PR DESCRIPTION
ruby-runtime 0.13 is broken and there seems to be no maintainer to fix it. See [JENKINS-37353](https://issues.jenkins-ci.org/browse/JENKINS-37353), [JENKINS-37771](https://issues.jenkins-ci.org/browse/JENKINS-37771) and [JENKINS-38145](https://issues.jenkins-ci.org/browse/JENKINS-38145).

According to the [metadata](https://repo.jenkins-ci.org/webapp/#/artifacts/browse/tree/General/releases/org/jenkins-ci/plugins/ruby-runtime/0.13/ruby-runtime-0.13.hpi) in Artifactory, 0.13 has been deployed by @eitoball. I tried to [ping](https://issues.jenkins-ci.org/browse/JENKINS-37353?focusedCommentId=282631&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-282631) him through JIRA a few days ago, but got no response.

Downgrading to 0.12 fixes the problems, so removing 0.13 from the Update Center will provide a better experience as 0.13 is the latest version which gets installed by default. I could not find any dependencies to 0.13 in `update-center.json`, so it should be save to pull that version.