### PR TITLE
JENKINS-41398 bitbucket-branch-source 2.0.1 is busted

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -127,6 +127,7 @@ branch-api-2.0.0
 branch-api-2.0.1
 github-branch-source-2.0.0
 cloudbees-bitbucket-branch-source-2.0.0
+cloudbees-bitbucket-branch-source-2.0.1
 github-organization-folder-1.6
 mercurial-1.58
 git-2.6.2


### PR DESCRIPTION
Antonio released this, but if you install it, the plugin won't load due to unresolved dependencies.