### PR TITLE
Suppress sse-gateway-1.14 due to unsatisfied dependency

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -135,3 +135,6 @@ git-3.0.2
 git-3.0.3
 workflow-multibranch-2.10
 pipeline-github-lib-1.0
+
+# Suppress sse-gateway 1.14  - it has unsatisfied dependency on pubsub-light 1.5
+sse-gateway-1.14


### PR DESCRIPTION
sse-gateway 1.14 has unsatisfied dependency of pubsub-light 1.5. This causes BlueOcean installations to fail.