### PR TITLE
Proactively suppress SCM API 2.0 and downstream

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -135,6 +135,33 @@ git-3.0.2
 git-3.0.3
 workflow-multibranch-2.10
 pipeline-github-lib-1.0
+# The components below are being prememptively blocked so that we can 
+# synchronize their release. To be followed by PR to unblock when we're ready.
+scm-api-2.0.2
+git-2.6.3
+git-3.0.4
+branch-api-2.0.2
+bitbucket-branch-source-2.0.2
+github-branch-source-plugin-2.0.1
+cloudbees-folder-5.17
+workflow-multibranch-2.11
+blueocean-1.0.0-b22
+blueocean-parent-1.0.0-b22
+blueocean-web-1.0.0-b22
+blueocean-dashboard-1.0.0-b22
+blueocean-personalization-1.0.0-b22
+blueocean-rest-1.0.0-b22
+blueocean-commons-1.0.0-b22
+blueocean-i18n-1.0.0-b22
+blueocean-jwt-1.0.0-b22
+blueocean-rest-impl-1.0.0-b22
+blueocean-pipeline-api-impl-1.0.0-b22
+blueocean-config-1.0.0-b22
+blueocean-github-pipeline-1.0.0-b22
+blueocean-git-pipeline-1.0.0-b22
+blueocean-display-url-1.0.0-b22
+blueocean-autofavorite-1.0.0-b22
+blueocean-rest-impl-1.0.0-b22
 
 # Suppress sse-gateway 1.14  - it has unsatisfied dependency on pubsub-light 1.5
 sse-gateway-1.14

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -159,8 +159,6 @@ blueocean-pipeline-api-impl-1.0.0-b22
 blueocean-config-1.0.0-b22
 blueocean-github-pipeline-1.0.0-b22
 blueocean-git-pipeline-1.0.0-b22
-blueocean-display-url-1.0.0-b22
-blueocean-autofavorite-1.0.0-b22
 blueocean-rest-impl-1.0.0-b22
 
 # Suppress sse-gateway 1.14  - it has unsatisfied dependency on pubsub-light 1.5

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -159,7 +159,6 @@ blueocean-pipeline-api-impl-1.0.0-b22
 blueocean-config-1.0.0-b22
 blueocean-github-pipeline-1.0.0-b22
 blueocean-git-pipeline-1.0.0-b22
-blueocean-rest-impl-1.0.0-b22
 
 # Suppress sse-gateway 1.14  - it has unsatisfied dependency on pubsub-light 1.5
 sse-gateway-1.14

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -159,6 +159,7 @@ blueocean-pipeline-api-impl-1.0.0-b22
 blueocean-config-1.0.0-b22
 blueocean-github-pipeline-1.0.0-b22
 blueocean-git-pipeline-1.0.0-b22
+blueocean-events-1.0.0-b22
 
 # Suppress sse-gateway 1.14  - it has unsatisfied dependency on pubsub-light 1.5
 sse-gateway-1.14


### PR DESCRIPTION
These are the plugins being released over the next 24 hours as a part of the SCM API 2.0 release.

We are proactively suppressing these plugins due to the complexity of this release. Some required dependencies are still blacklisted and some blue ocean parts will be released by that team later in the day. All plugins must be upgraded simultaneously by the user to avoid breaking anything, so contents must appear as simultaneously as possible.

By preemptively blocking these, we can precisely choose the timing of the coordinated release by merging a followup PR which reverts the block. 