### PR TITLE
Ignores additions from wiki

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -33,6 +33,7 @@ foofoo                           # junk: contains only the HelloWorldBuilder sam
 gerrit                           # superseded by Gerrit Trigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
 girls                            # no... just... no -- https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
 gitorious                        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
+google-desktop-gadget            # Google Desktop has been discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hudson+Google+Desktop+Gadget
 googlecode                       # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
 hall-jenkins                     # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
 hello-world                      # people shouldn't actually *publish* the sample project!
@@ -61,6 +62,7 @@ karotz                           # service discontinued: https://twitter.com/Kar
 kato                             # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kato+Plugin
 koji-plugin                      # renamed to koji
 kundo                            # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kundo+Plugin
+lechat                           # renamed to Kata which was discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/LeChat+Plugin
 liverebel-deploy                 # only worked with obsolete releases -- https://wiki.jenkins-ci.org/display/JENKINS/LiveRebel+Plugin
 m2-extra-steps                   # part of core functionality since 1.433 -- https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
 mansion-cloud                    # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
@@ -69,6 +71,7 @@ mogotest                         # deprecated: mogotest service no longer exists
 mypeople                         # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
 nabaztag                         # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
 netio-plugin                     # product discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
+nodeofflinenotification          # superseded by Mail Watcher Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Node+Offline+Notification+Plugin
 notifo                           # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
 octoperf-jenkins-plugin          # released from wrong repository; will be renamed
 openstack-plugin                 # renamed to openstack-cloud
@@ -97,6 +100,7 @@ script-realm-extended            # fork of a plugin and has since been subsumed 
 secret                           # superseded by Credentials Binding Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
 security-no-captcha              # Functionality integrated in Jenkins 1.416 -- https://wiki.jenkins-ci.org/display/JENKINS/Security+No+CAPTCHA
 serenitec                        # gbossert asked to remove this plugin
+setenv                           # superseded by envinject -- https://wiki.jenkins-ci.org/display/JENKINS/Setenv+Plugin
 skytap-cloud-plugin              # renamed to skytap
 sms-notification                 # renamed to sms
 sonatype-ci                      # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -1,80 +1,84 @@
 # This file lists artifactId or artifactId-version values to hide in update center.
 
-ConfigurationSlicing      # renamed into configurationslicing, and this double causes a check out problem on Windows
-description-column        # renamed to description-column-plugin
-hudson-startup-trigger    # renamed to startup-trigger-plugin
-integrity                 # renamed to integrity-plugin
-ivy2                      # subsumed into the ivy plugin
-jmeter                    # renamed to performance
-PerfPublisher             # latest releases use "perfpublisher"
-scis-ad                   # deprecated
-serenitec                 # gbossert asked to remove this plugin
-wsnotifier                # renamed to websocket
-BlameSubversion-1.121     # big number but not the latest release
-rebuild-1.2               # release troubles.. skip these
-rebuild-1.3               # ??
-wsnotifier                # renamed to websocket.
+AntepediaReporter-CI-plugin # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
 assembla-jenkins          # Renamed to assembla
-pathignore-plugin         # renamed to pathignore
 associated-files-plugin   # renamed to associated-files
-vagrant-plugin            # renamed to vagrant, herpderp
-blitz.io-jenkins          # renamed to blitz_io-jenkins
-sahagin-jenkins-plugin    # renamed to sahagin-plugin
-jgiven-plugin             # renamed to jgiven
-openstack-plugin          # renamed to openstack-cloud
-matrix-project-1.4.1      # this specific version is excluded for INFRA-250
-matrix-project-1.2.1      # also INFRA-250
-rtc                       # superseded by Team Concert Plugin
-HiddenParameter           # renamed to hidden-parameter
-sample                    # junk plugin; developer has been banned
-ChatRoom                  # junk plugin; developer has been banned
-mcap-eas-plugin           # superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
-Relution                  # renamed to relution-publisher
-rally-update-plugin-1     # renamed to rally-plugin(!)
-skytap-cloud-plugin       # renamed to skytap
-sonatype-ci               # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
-TestExecuter              # renamed to selected-tests-executor
-TestResultsAnalyzer       # renamed to test-results-analyzer
-jenkinswalldisplay-pom    # renamed to jenkinswalldisplay
-perfectomobile-jenkins    # renamed to perfectomobile
-paaslane                  # renamed to paaslane-estimate
-sms-notification          # renamed to sms
 aws-lambda-jenkins-plugin # renamed to aws-lambda
 aws-lambda-plugin         # renamed to aws-lambda
 aws-yum-paramater         # renamed to package-parameter
-aws-yum-parameter         # renamed to package-parameter
-hipchat-plugin            # renamed to hipchat
-hudson-logaction-plugin   # renamed to logaction-plugin
-icon-shim-plugin          # renamed to icon-shim
-mogotest                  # deprecated: mogotest service no longer exists
+bees-sdk-plugin           # removal requested by ndeloof: RUN@cloud service no longer exists
+blackduck-installer		   # deprecated
+blitz.io-jenkins          # renamed to blitz_io-jenkins
+ChatRoom                  # junk plugin; developer has been banned
 ColumnPack-plugin         # renamed to ColumnsPlugin
-release-test              # junk: contains only the HelloWorldBuilder sample
-release-multi-test        # junk: contains only the HelloWorldBuilder sample
-uithemes                  # removal requested by tfennelly
-jslint-checkstyle         # renamed to jshint-checkstyle
-jshint-checkstyle         # deprecated
-zaproxy-jenkins           # renamed to zaproxy
+ConfigurationSlicing      # renamed into configurationslicing, and this double causes a check out problem on Windows
 create-fingerprint-plugin # renamed to create-fingerprint
-jenkins-leiningen         # renamed to leiningen-plugin :'(
-schedule-build-plugin     # renamed to schedule-build
-weibo4jenkins             # renamed to weibo
+datadog-build-reporter    # renamed to datadog
+description-column        # renamed to description-column-plugin
 dockerhub                 # removal requested by teilo, superceded by dockerhub-notification
 drools                    # deprecated
 foofoo                    # junk: contains only the HelloWorldBuilder sample
 hello-world               # people shouldn't actually *publish* the sample project!
-bees-sdk-plugin           # removal requested by ndeloof: RUN@cloud service no longer exists
-koji-plugin               # renamed to koji
-rally-bookkeeper          # removal requested by Mike Rogers: will be Rally plugin 2.0
-ssh2easy-plugin           # removal requested by plugin author, accidental rename
-AntepediaReporter-CI-plugin # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
-datadog-build-reporter    # renamed to datadog
-fortify-on-demand-uploader-1.0 # removal requested by Ryan Black, plugin wasn't ready for release
-poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
-octoperf-jenkins-plugin   # released from wrong repository; will be renamed
-upload-artifacts-to-nexus # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
-blackduck-installer		  # deprecated
-jbehave-hudson-plugin   # renamed to jbehave-jenkins-plugin
+HiddenParameter           # renamed to hidden-parameter
+hipchat-plugin            # renamed to hipchat
+hudson-logaction-plugin   # renamed to logaction-plugin
+hudson-startup-trigger    # renamed to startup-trigger-plugin
+icon-shim-plugin          # renamed to icon-shim
+integrity                 # renamed to integrity-plugin
+ivy2                      # subsumed into the ivy plugin
+jbehave-hudson-plugin     # renamed to jbehave-jenkins-plugin
+jenkins-leiningen         # renamed to leiningen-plugin :'(
+jenkinswalldisplay-pom    # renamed to jenkinswalldisplay
+jgiven-plugin             # renamed to jgiven
+jmeter                    # renamed to performance
+jshint-checkstyle         # deprecated
+jslint-checkstyle         # renamed to jshint-checkstyle
 kanboard-publisher        # renamed to kanboard, see https://issues.jenkins-ci.org/browse/HOSTING-241?focusedCommentId=280720&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280720
+koji-plugin               # renamed to koji
+mcap-eas-plugin           # superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
+mogotest                  # deprecated: mogotest service no longer exists
+octoperf-jenkins-plugin   # released from wrong repository; will be renamed
+octoperf-jenkins-plugin   # released from wrong repository; will be renamed
+openstack-plugin          # renamed to openstack-cloud
+paaslane                  # renamed to paaslane-estimate
+pathignore-plugin         # renamed to pathignore
+perfectomobile-jenkins    # renamed to perfectomobile
+PerfPublisher             # latest releases use "perfpublisher"
+poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
+poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
+rally-bookkeeper          # removal requested by Mike Rogers: will be Rally plugin 2.0
+rally-update-plugin-1     # renamed to rally-plugin(!)
+release-multi-test        # junk: contains only the HelloWorldBuilder sample
+release-test              # junk: contains only the HelloWorldBuilder sample
+Relution                  # renamed to relution-publisher
+rtc                       # superseded by Team Concert Plugin
+sahagin-jenkins-plugin    # renamed to sahagin-plugin
+sample                    # junk plugin; developer has been banned
+schedule-build-plugin     # renamed to schedule-build
+scis-ad                   # deprecated
+serenitec                 # gbossert asked to remove this plugin
+skytap-cloud-plugin       # renamed to skytap
+sms-notification          # renamed to sms
+sonatype-ci               # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
+ssh2easy-plugin           # removal requested by plugin author, accidental rename
+TestExecuter              # renamed to selected-tests-executor
+TestResultsAnalyzer       # renamed to test-results-analyzer
+uithemes                  # removal requested by tfennelly
+upload-artifacts-to-nexus # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
+upload-artifacts-to-nexus # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
+vagrant-plugin            # renamed to vagrant, herpderp
+weibo4jenkins             # renamed to weibo
+wsnotifier                # renamed to websocket
+zaproxy-jenkins           # renamed to zaproxy
+
+
+# specific releases
+BlameSubversion-1.121     # big number but not the latest release
+fortify-on-demand-uploader-1.0 # removal requested by Ryan Black, plugin wasn't ready for release
+matrix-project-1.2.1      # also INFRA-250
+matrix-project-1.4.1      # this specific version is excluded for INFRA-250
+rebuild-1.2               # release troubles.. skip these
+rebuild-1.3               # ??
 ruby-runtime-0.13         # JENKINS-37353, JENKINS-37771 and JENKINS-38145
 
 # rogue releases with unknown source

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -1,23 +1,40 @@
 # This file lists artifactId or artifactId-version values to hide in update center.
 
 AntepediaReporter-CI-plugin      # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
+appthwack                        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/AppThwack+Plugin
 assembla-jenkins                 # Renamed to assembla
 associated-files-plugin          # renamed to associated-files
 aws-lambda-jenkins-plugin        # renamed to aws-lambda
 aws-lambda-plugin                # renamed to aws-lambda
 aws-yum-paramater                # renamed to package-parameter
 bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists
-blackduck-installer              # deprecated
+blackduck-installer              # "This plugin is no longer supported and should not be used." -- https://wiki.jenkins-ci.org/display/JENKINS/Black+Duck+Vulnerability+Installer+Plugin
 blitz.io-jenkins                 # renamed to blitz_io-jenkins
+build-node-column                # superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
+buildcoin-plugin                 # service discontinued: https://github.com/github/github-services/pull/538 -- https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
+buildheroes-plugin               # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
+caroline                         # service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
 ChatRoom                         # junk plugin; developer has been banned
+cifs                             # Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
+cloudbees-deployer-plugin        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Cloudbees+Deployer+Plugin
+cloudbees-enterprise-plugins     # Unsupported and retracted by service provider -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Jenkins+Enterprise
+cloudbees-registration           # "This feature is no longer relevant." -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Registration+Plugin
 ColumnPack-plugin                # renamed to ColumnsPlugin
 ConfigurationSlicing             # renamed into configurationslicing, and this double causes a check out problem on Windows
+copyarchiver                     # superseded by ArtifactDeployer Plugin  -- https://wiki.jenkins-ci.org/display/JENKINS/CopyArchiver+Plugin
+cppunit                          # Incompatible with Hudson 1.355+ and superseded by xUnit Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CppUnit+Plugin
 create-fingerprint-plugin        # renamed to create-fingerprint
 datadog-build-reporter           # renamed to datadog
 description-column               # renamed to description-column-plugin
 dockerhub                        # removal requested by teilo, superceded by dockerhub-notification
 drools                           # deprecated
+emotional-hudson                 # Superseded by Emotional Jenkins -- https://wiki.jenkins-ci.org/display/JENKINS/Emotional+Hudson+Plugin
 foofoo                           # junk: contains only the HelloWorldBuilder sample
+gerrit                           # superseded by Gerrit Trigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Plugin
+girls                            # no... just... no -- https://wiki.jenkins-ci.org/display/JENKINS/Girls+Plugin
+gitorious                        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Gitorious+Plugin
+googlecode                       # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Google+Code+Plugin
+hall-jenkins                     # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Hall+Plugin
 hello-world                      # people shouldn't actually *publish* the sample project!
 HiddenParameter                  # renamed to hidden-parameter
 hipchat-plugin                   # renamed to hipchat
@@ -25,25 +42,46 @@ hudson-logaction-plugin          # renamed to logaction-plugin
 hudson-startup-trigger           # renamed to startup-trigger-plugin
 icon-shim-plugin                 # renamed to icon-shim
 integrity                        # renamed to integrity-plugin
+ion-deployer                     # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
 ivy2                             # subsumed into the ivy plugin
+javanet                          # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
+javanet-uploader                 # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin
 jbehave-hudson-plugin            # renamed to jbehave-jenkins-plugin
 jenkins-leiningen                # renamed to leiningen-plugin :'(
 jenkinswalldisplay-pom           # renamed to jenkinswalldisplay
+jenkow-activiti-designer         # unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Designer
+jenkow-activiti-explorer         # unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Activiti+Explorer
+jenkow-plugin                    # unmaintained -- https://wiki.jenkins-ci.org/display/JENKINS/Jenkow+Plugin
 jgiven-plugin                    # renamed to jgiven
 jmeter                           # renamed to performance
 jshint-checkstyle                # deprecated
 jslint-checkstyle                # renamed to jshint-checkstyle
 kanboard-publisher               # renamed to kanboard, see https://issues.jenkins-ci.org/browse/HOSTING-241?focusedCommentId=280720&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280720
+karotz                           # service discontinued: https://twitter.com/Karotz/status/527852693960658944 -- https://wiki.jenkins-ci.org/display/JENKINS/Karotz+Plugin
+kato                             # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kato+Plugin
 koji-plugin                      # renamed to koji
+kundo                            # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Kundo+Plugin
+liverebel-deploy                 # only worked with obsolete releases -- https://wiki.jenkins-ci.org/display/JENKINS/LiveRebel+Plugin
+m2-extra-steps                   # part of core functionality since 1.433 -- https://wiki.jenkins-ci.org/display/JENKINS/M2+Extra+Steps+Plugin
+mansion-cloud                    # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Cloud+Connector+Plugin
 mcap-eas-plugin                  # superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
 mogotest                         # deprecated: mogotest service no longer exists
+mypeople                         # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/MyPeople+Plugin
+nabaztag                         # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Nabaztag+Plugin
+netio-plugin                     # product discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Netio-Plugin
+notifo                           # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Notifo+Plugin
 octoperf-jenkins-plugin          # released from wrong repository; will be renamed
 openstack-plugin                 # renamed to openstack-cloud
+origo-issue-notifier             # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Origo+Issue+Notifier
+otabuilder                       # latest sources at https://github.com/jeslyvarghese/otabuilder-plugin but discontinued due to tool chain discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Over-the-Air+Ad+Hoc+Deployment+Plugin+For+iOS
 paaslane                         # renamed to paaslane-estimate
 pathignore-plugin                # renamed to pathignore
 perfectomobile-jenkins           # renamed to perfectomobile
 PerfPublisher                    # latest releases use "perfpublisher"
+pipeline-editor                  # Unclear, but probably removed by author -- TODO ask Michael Neale -- https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Editor+Plugin
 poll-mailbox-trigger             # renamed to poll-mailbox-trigger-plugin :(
+pretest-commit                   # discontinued PoC, use Pretested Integration Plugin instead -- https://wiki.jenkins-ci.org/display/JENKINS/Pretest+Commit+Plugin
+PUCM                             # superseded by ClearCase UCM Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/pucm+plugin
 rally-bookkeeper                 # removal requested by Mike Rogers: will be Rally plugin 2.0
 rally-update-plugin-1            # renamed to rally-plugin(!)
 release-multi-test               # junk: contains only the HelloWorldBuilder sample
@@ -53,20 +91,31 @@ rtc                              # superseded by Team Concert Plugin
 sahagin-jenkins-plugin           # renamed to sahagin-plugin
 sample                           # junk plugin; developer has been banned
 schedule-build-plugin            # renamed to schedule-build
+schedule-failed-builds           # superseded by Naginator Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Retry+Failed+Builds+Plugin
 scis-ad                          # deprecated
+script-realm-extended            # fork of a plugin and has since been subsumed -- https://wiki.jenkins-ci.org/display/JENKINS/Script+Security+Realm+Extended
+secret                           # superseded by Credentials Binding Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Secret+Plugin
+security-no-captcha              # Functionality integrated in Jenkins 1.416 -- https://wiki.jenkins-ci.org/display/JENKINS/Security+No+CAPTCHA
 serenitec                        # gbossert asked to remove this plugin
 skytap-cloud-plugin              # renamed to skytap
 sms-notification                 # renamed to sms
 sonatype-ci                      # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
 ssh2easy-plugin                  # removal requested by plugin author, accidental rename
+tepco                            # unused? -- https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Plugin
+tepco-epuw                       # unused? -- https://wiki.jenkins-ci.org/display/JENKINS/TEPCO+Electric+Power+Usage+Widget
 TestExecuter                     # renamed to selected-tests-executor
+testflight                       # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Testflight+Plugin
 TestResultsAnalyzer              # renamed to test-results-analyzer
+tusarnotifier                    # superseded by DTKit Plugin with automatic migration -- https://wiki.jenkins-ci.org/display/JENKINS/TusarNotifier
 uithemes                         # removal requested by tfennelly
 upload-artifacts-to-nexus        # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
+url-change-trigger               # Superseded by URLTrigger Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/URL+Change+Trigger
 vagrant-plugin                   # renamed to vagrant, herpderp
 weibo4jenkins                    # renamed to weibo
 wsnotifier                       # renamed to websocket
+zaproxy                          # superseded by zap -- https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin
 zaproxy-jenkins                  # renamed to zaproxy
+zubhium                          # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Zubhium+Plugin
 
 
 

--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -1,75 +1,73 @@
 # This file lists artifactId or artifactId-version values to hide in update center.
 
-AntepediaReporter-CI-plugin # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
-assembla-jenkins          # Renamed to assembla
-associated-files-plugin   # renamed to associated-files
-aws-lambda-jenkins-plugin # renamed to aws-lambda
-aws-lambda-plugin         # renamed to aws-lambda
-aws-yum-paramater         # renamed to package-parameter
-bees-sdk-plugin           # removal requested by ndeloof: RUN@cloud service no longer exists
-blackduck-installer		   # deprecated
-blitz.io-jenkins          # renamed to blitz_io-jenkins
-ChatRoom                  # junk plugin; developer has been banned
-ColumnPack-plugin         # renamed to ColumnsPlugin
-ConfigurationSlicing      # renamed into configurationslicing, and this double causes a check out problem on Windows
-create-fingerprint-plugin # renamed to create-fingerprint
-datadog-build-reporter    # renamed to datadog
-description-column        # renamed to description-column-plugin
-dockerhub                 # removal requested by teilo, superceded by dockerhub-notification
-drools                    # deprecated
-foofoo                    # junk: contains only the HelloWorldBuilder sample
-hello-world               # people shouldn't actually *publish* the sample project!
-HiddenParameter           # renamed to hidden-parameter
-hipchat-plugin            # renamed to hipchat
-hudson-logaction-plugin   # renamed to logaction-plugin
-hudson-startup-trigger    # renamed to startup-trigger-plugin
-icon-shim-plugin          # renamed to icon-shim
-integrity                 # renamed to integrity-plugin
-ivy2                      # subsumed into the ivy plugin
-jbehave-hudson-plugin     # renamed to jbehave-jenkins-plugin
-jenkins-leiningen         # renamed to leiningen-plugin :'(
-jenkinswalldisplay-pom    # renamed to jenkinswalldisplay
-jgiven-plugin             # renamed to jgiven
-jmeter                    # renamed to performance
-jshint-checkstyle         # deprecated
-jslint-checkstyle         # renamed to jshint-checkstyle
-kanboard-publisher        # renamed to kanboard, see https://issues.jenkins-ci.org/browse/HOSTING-241?focusedCommentId=280720&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280720
-koji-plugin               # renamed to koji
-mcap-eas-plugin           # superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
-mogotest                  # deprecated: mogotest service no longer exists
-octoperf-jenkins-plugin   # released from wrong repository; will be renamed
-octoperf-jenkins-plugin   # released from wrong repository; will be renamed
-openstack-plugin          # renamed to openstack-cloud
-paaslane                  # renamed to paaslane-estimate
-pathignore-plugin         # renamed to pathignore
-perfectomobile-jenkins    # renamed to perfectomobile
-PerfPublisher             # latest releases use "perfpublisher"
-poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
-poll-mailbox-trigger      # renamed to poll-mailbox-trigger-plugin :(
-rally-bookkeeper          # removal requested by Mike Rogers: will be Rally plugin 2.0
-rally-update-plugin-1     # renamed to rally-plugin(!)
-release-multi-test        # junk: contains only the HelloWorldBuilder sample
-release-test              # junk: contains only the HelloWorldBuilder sample
-Relution                  # renamed to relution-publisher
-rtc                       # superseded by Team Concert Plugin
-sahagin-jenkins-plugin    # renamed to sahagin-plugin
-sample                    # junk plugin; developer has been banned
-schedule-build-plugin     # renamed to schedule-build
-scis-ad                   # deprecated
-serenitec                 # gbossert asked to remove this plugin
-skytap-cloud-plugin       # renamed to skytap
-sms-notification          # renamed to sms
-sonatype-ci               # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
-ssh2easy-plugin           # removal requested by plugin author, accidental rename
-TestExecuter              # renamed to selected-tests-executor
-TestResultsAnalyzer       # renamed to test-results-analyzer
-uithemes                  # removal requested by tfennelly
-upload-artifacts-to-nexus # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
-upload-artifacts-to-nexus # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
-vagrant-plugin            # renamed to vagrant, herpderp
-weibo4jenkins             # renamed to weibo
-wsnotifier                # renamed to websocket
-zaproxy-jenkins           # renamed to zaproxy
+AntepediaReporter-CI-plugin      # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
+assembla-jenkins                 # Renamed to assembla
+associated-files-plugin          # renamed to associated-files
+aws-lambda-jenkins-plugin        # renamed to aws-lambda
+aws-lambda-plugin                # renamed to aws-lambda
+aws-yum-paramater                # renamed to package-parameter
+bees-sdk-plugin                  # removal requested by ndeloof: RUN@cloud service no longer exists
+blackduck-installer              # deprecated
+blitz.io-jenkins                 # renamed to blitz_io-jenkins
+ChatRoom                         # junk plugin; developer has been banned
+ColumnPack-plugin                # renamed to ColumnsPlugin
+ConfigurationSlicing             # renamed into configurationslicing, and this double causes a check out problem on Windows
+create-fingerprint-plugin        # renamed to create-fingerprint
+datadog-build-reporter           # renamed to datadog
+description-column               # renamed to description-column-plugin
+dockerhub                        # removal requested by teilo, superceded by dockerhub-notification
+drools                           # deprecated
+foofoo                           # junk: contains only the HelloWorldBuilder sample
+hello-world                      # people shouldn't actually *publish* the sample project!
+HiddenParameter                  # renamed to hidden-parameter
+hipchat-plugin                   # renamed to hipchat
+hudson-logaction-plugin          # renamed to logaction-plugin
+hudson-startup-trigger           # renamed to startup-trigger-plugin
+icon-shim-plugin                 # renamed to icon-shim
+integrity                        # renamed to integrity-plugin
+ivy2                             # subsumed into the ivy plugin
+jbehave-hudson-plugin            # renamed to jbehave-jenkins-plugin
+jenkins-leiningen                # renamed to leiningen-plugin :'(
+jenkinswalldisplay-pom           # renamed to jenkinswalldisplay
+jgiven-plugin                    # renamed to jgiven
+jmeter                           # renamed to performance
+jshint-checkstyle                # deprecated
+jslint-checkstyle                # renamed to jshint-checkstyle
+kanboard-publisher               # renamed to kanboard, see https://issues.jenkins-ci.org/browse/HOSTING-241?focusedCommentId=280720&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-280720
+koji-plugin                      # renamed to koji
+mcap-eas-plugin                  # superseded by Relution Publisher (see https://github.com/mwaylabs/jenkins-mcap-eas-plugin)
+mogotest                         # deprecated: mogotest service no longer exists
+octoperf-jenkins-plugin          # released from wrong repository; will be renamed
+openstack-plugin                 # renamed to openstack-cloud
+paaslane                         # renamed to paaslane-estimate
+pathignore-plugin                # renamed to pathignore
+perfectomobile-jenkins           # renamed to perfectomobile
+PerfPublisher                    # latest releases use "perfpublisher"
+poll-mailbox-trigger             # renamed to poll-mailbox-trigger-plugin :(
+rally-bookkeeper                 # removal requested by Mike Rogers: will be Rally plugin 2.0
+rally-update-plugin-1            # renamed to rally-plugin(!)
+release-multi-test               # junk: contains only the HelloWorldBuilder sample
+release-test                     # junk: contains only the HelloWorldBuilder sample
+Relution                         # renamed to relution-publisher
+rtc                              # superseded by Team Concert Plugin
+sahagin-jenkins-plugin           # renamed to sahagin-plugin
+sample                           # junk plugin; developer has been banned
+schedule-build-plugin            # renamed to schedule-build
+scis-ad                          # deprecated
+serenitec                        # gbossert asked to remove this plugin
+skytap-cloud-plugin              # renamed to skytap
+sms-notification                 # renamed to sms
+sonatype-ci                      # deprecated (see Sonatype CLM: https://wiki.jenkins-ci.org/x/iYDPAw)
+ssh2easy-plugin                  # removal requested by plugin author, accidental rename
+TestExecuter                     # renamed to selected-tests-executor
+TestResultsAnalyzer              # renamed to test-results-analyzer
+uithemes                         # removal requested by tfennelly
+upload-artifacts-to-nexus        # renamed, see https://issues.jenkins-ci.org/browse/HOSTING-41?focusedCommentId=250383&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-250383
+vagrant-plugin                   # renamed to vagrant, herpderp
+weibo4jenkins                    # renamed to weibo
+wsnotifier                       # renamed to websocket
+zaproxy-jenkins                  # renamed to zaproxy
+
 
 
 # specific releases


### PR DESCRIPTION
Additions from `plugin-deprecated` label in an effort to start relying less on the wiki for building the update site.

https://wiki.jenkins-ci.org/labels/viewlabel.action?ids=46727211&key=JENKINS&startIndex=0

@orrc @rtyler @batmat 