### PR TITLE
Add/fix the last few wiki-blacklisted plugins

### DIFF
--- a/src/main/resources/artifact-ignores.properties
+++ b/src/main/resources/artifact-ignores.properties
@@ -2,6 +2,7 @@
 
 AntepediaReporter-CI-plugin      # closed-souce plugin; removal confirmed with owner, Guillaume Rousseau
 appthwack                        # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/AppThwack+Plugin
+assembla-oauth                   # renamed to assembla-auth https://groups.google.com/d/msg/jenkinsci-dev/TVz-D5etsUM/Knx9zXtEnSwJ
 assembla-jenkins                 # Renamed to assembla
 associated-files-plugin          # renamed to associated-files
 aws-lambda-jenkins-plugin        # renamed to aws-lambda
@@ -12,7 +13,7 @@ blackduck-installer              # "This plugin is no longer supported and shoul
 blitz.io-jenkins                 # renamed to blitz_io-jenkins
 build-node-column                # superseded by Extra Columns Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/Build+Node+Column+Plugin
 buildcoin-plugin                 # service discontinued: https://github.com/github/github-services/pull/538 -- https://wiki.jenkins-ci.org/display/JENKINS/Buildcoin+Plugin
-buildheroes-plugin               # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
+buildheroes                      # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Buildheroes
 caroline                         # service shut down -- https://wiki.jenkins-ci.org/display/JENKINS/Caroline+Plugin
 ChatRoom                         # junk plugin; developer has been banned
 cifs                             # Superseded by Publish Over CIFS Plugin -- https://wiki.jenkins-ci.org/display/JENKINS/CIFS-Publisher+Plugin
@@ -43,7 +44,7 @@ hudson-logaction-plugin          # renamed to logaction-plugin
 hudson-startup-trigger           # renamed to startup-trigger-plugin
 icon-shim-plugin                 # renamed to icon-shim
 integrity                        # renamed to integrity-plugin
-ion-deployer                     # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
+ion-deployer-plugin              # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/iON+Deployer+Plugin
 ivy2                             # subsumed into the ivy plugin
 javanet                          # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/Java.net+Plugin
 javanet-uploader                 # service discontinued -- https://wiki.jenkins-ci.org/display/JENKINS/java.net+uploader+Plugin


### PR DESCRIPTION
- assembla-oauth: Missed it because wiki page has no useful info
- buildheroes: wiki macro had wrong ID
- ion-deployer-plugin: I misread the wiki macro

Followup to https://github.com/jenkinsci/backend-update-center2/pull/111

CC @orrc @rtyler @batmat